### PR TITLE
Refactor to view builders

### DIFF
--- a/Leomard/Views/FeedView.swift
+++ b/Leomard/Views/FeedView.swift
@@ -84,61 +84,68 @@ struct FeedView: View {
         }
     }
     
-    /// Infinite scrolling view for this feed's content
     @ViewBuilder
     private var feedContent: some View {
         VStack {
             // - TODO: GeometryReader is used to dynamically show/hide site sidebar. This proxy is expensive, could be replaced with `.preference(key...)` view modifier instead?
             GeometryReader { proxy in
                 HStack {
-                    // - TODO: `scrollProxy` is expensive and isn't being used, remove?
-                    ScrollViewReader { scrollProxy in
-                        List {
-                            ForEach(postsResponse.posts, id: \.self) { postView in
-                                PostUIView(postView: postView, shortBody: true, postService: self.postService!, myself: $myself, contentView: contentView)
-                                    .onAppear {
-                                        if postView == self.postsResponse.posts.last {
-                                            self.loadPosts()
-                                        }
-                                    }
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                Spacer()
-                            }
-                        }
-                        .frame(
-                            minWidth: 0,
-                            maxWidth: 600,
-                            maxHeight: .infinity,
-                            alignment: .center
-                        )
-                    }
-                    
-                    if proxy.size.width > 1000 {
-                        List {
-                            VStack {
-                                if siteView != nil {
-                                    PageSidebarUIView(siteView: $siteView)
-                                }
-                            }
-                            .frame(
-                                minWidth: 0,
-                                maxWidth: .infinity
-                            )
-                            .cornerRadius(4)
-                        }
+                    feedPostsList
+                    feedPageSidebar(visible: proxy.size.width > 1000)
                         .frame(
                             minWidth: 0,
                             maxWidth: 400,
                             maxHeight: .infinity,
                             alignment: .center
                         )
-                    }
                 }
                 .frame(
                     maxWidth: .infinity,
                     alignment: .center
                 )
             }
+        }
+    }
+    
+    /// Infinite scrolling view for this feed's content
+    @ViewBuilder
+    private var feedPostsList: some View {
+        // - TODO: `scrollProxy` is expensive and isn't being used, remove?
+        ScrollViewReader { scrollProxy in
+            List {
+                ForEach(postsResponse.posts, id: \.self) { postView in
+                    PostUIView(postView: postView, shortBody: true, postService: self.postService!, myself: $myself, contentView: contentView)
+                        .onAppear {
+                            if postView == self.postsResponse.posts.last {
+                                self.loadPosts()
+                            }
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    Spacer()
+                }
+            }
+            .frame(
+                minWidth: 0,
+                maxWidth: 600,
+                maxHeight: .infinity,
+                alignment: .center
+            )
+        }
+    }
+    
+    @ViewBuilder
+    private func feedPageSidebar(visible: Bool) -> some View {
+        List {
+            VStack {
+                if siteView != nil {
+                    PageSidebarUIView(siteView: $siteView)
+                }
+            }
+            .frame(
+                minWidth: 0,
+                maxWidth: .infinity
+            )
+            .cornerRadius(4)
         }
     }
     

--- a/Leomard/Views/FeedView.swift
+++ b/Leomard/Views/FeedView.swift
@@ -27,6 +27,26 @@ struct FeedView: View {
     @Binding var siteView: SiteView?
 
     var body: some View {
+        feedToolbar
+            .frame(
+                minWidth: 0,
+                idealWidth: .infinity
+            )
+        feedContent
+            .cornerRadius(4)
+            .task {
+                self.postService = PostService(requestHandler: RequestHandler())
+                loadPosts()
+            }
+            .onDisappear {
+                self.postsResponse = GetPostsResponse()
+            }
+        Spacer()
+    }
+    
+    /// For commonly-used button actions like sort and reload.
+    @ViewBuilder
+    private var feedToolbar: some View {
         HStack {
             HStack {
                 Image(systemName: selectedListing.image)
@@ -62,10 +82,11 @@ struct FeedView: View {
                 Image(systemName: "arrow.clockwise")
             }
         }
-        .frame(
-            minWidth: 0,
-            idealWidth: .infinity
-        )
+    }
+    
+    /// Infinite scrolling view for this feed's content
+    @ViewBuilder
+    private var feedContent: some View {
         VStack {
             GeometryReader { proxy in
                 HStack {
@@ -117,15 +138,6 @@ struct FeedView: View {
                 )
             }
         }
-        .cornerRadius(4)
-        .task {
-            self.postService = PostService(requestHandler: RequestHandler())
-            loadPosts()
-        }
-        .onDisappear {
-            self.postsResponse = GetPostsResponse()
-        }
-        Spacer()
     }
     
     func loadPosts() {

--- a/Leomard/Views/FeedView.swift
+++ b/Leomard/Views/FeedView.swift
@@ -88,8 +88,10 @@ struct FeedView: View {
     @ViewBuilder
     private var feedContent: some View {
         VStack {
+            // - TODO: GeometryReader is used to dynamically show/hide site sidebar. This proxy is expensive, could be replaced with `.preference(key...)` view modifier instead?
             GeometryReader { proxy in
                 HStack {
+                    // - TODO: `scrollProxy` is expensive and isn't being used, remove?
                     ScrollViewReader { scrollProxy in
                         List {
                             ForEach(postsResponse.posts, id: \.self) { postView in

--- a/Leomard/Views/InboxView.swift
+++ b/Leomard/Views/InboxView.swift
@@ -34,105 +34,17 @@ struct InboxView: View {
     
     var body: some View {
         VStack {
-            HStack {
-                Spacer()
-                Image(systemName: selectedView.imageName)
-                    .padding(.trailing, 0)
-                Picker("", selection: $selectedView) {
-                    ForEach(views, id: \.self) { method in
-                        Text(String(describing: method.title))
-                    }
-                }
-                .frame(maxWidth: 160)
-                .padding(.leading, -10)
-                .onChange(of: selectedView) { value in
-                    self.page = 1
-                    self.loadContent()
-                }
-                if selectedView == views[0] {
-                    Image(systemName: selectedCommentSortType.image)
-                        .padding(.trailing, 0)
-                    Picker("", selection: $selectedCommentSortType) {
-                        ForEach(CommentSortType.allCases, id: \.self) { method in
-                            Text(String(describing: method))
-                        }
-                    }
-                    .frame(maxWidth: 80)
-                    .padding(.leading, -10)
-                    .onChange(of: selectedCommentSortType) { value in
-                        self.page = 1
-                        self.loadContent()
-                    }
-                }
-                Button(action: {
-                    self.page = 1
-                    self.loadContent()
-                }) {
-                    Image(systemName: "arrow.clockwise")
-                }
-                Toggle("Unread Only", isOn: $unreadOnly)
-                    .onChange(of: unreadOnly) { value in
-                        self.page = 1
-                        self.loadContent()
-                    }
-                Spacer()
-                if selectedView == views[0] {
-                    Button(action: markAllAsRead) {
-                        Image(systemName: "envelope.open")
-                    }.buttonStyle(.link)
-                }
-            }
-            .padding(.leading)
-            .padding(.trailing)
+            toolbar
+                .padding(.leading)
+                .padding(.trailing)
+            
             List {
-                if isLoading {
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                }
-                
-                switch selectedView {
-                case views[1]:
-                    if privateMessages.count == 0 && !isLoading {
-                        Text("You don't have any private messages.")
-                            .foregroundColor(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                    }
-                    ForEach(privateMessages, id: \.self) { privateMessage in
-                        PrivateMessageUIView(privateMessageView: privateMessage, privateMessageService: privateMessageService!, myself: $myself, contentView: self.contentView, unreadOnlyMode: $unreadOnly)
-                            .onAppear {
-                                if privateMessage == privateMessages.last {
-                                    page += 1
-                                    loadContent()
-                                }
-                            }
-                        Spacer()
-                    }
-                default:
-                    if commentReplies.count == 0 && !isLoading {
-                        Text("You don't have any replies.")
-                            .foregroundColor(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                    }
-                    ForEach(commentReplies, id: \.self) { commentReply in
-                        CommentReplyUIView(commentReplyView: commentReply, commentService: commentService, myself: $myself, contentView: contentView, unreadOnlyMode: $unreadOnly)
-                            .onAppear {
-                                if commentReply == commentReplies.last {
-                                    page += 1
-                                    loadContent()
-                                }
-                            }
-                        Spacer()
-                    }
-                }
+                loadingIndicator(visible: isLoading)
+                inboxContents(for: selectedView)
             }
             .frame(maxWidth: 600, maxHeight: .infinity)
-            if selectedView == views[1] {
-                Spacer()
-                Text("DISCLAIMER: Private messages in Lemmy are not secure.")
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .center)
-            }
+            
+            footerText
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .task {
@@ -142,6 +54,133 @@ struct InboxView: View {
             self.loadContent()
         }
     }
+    
+    // MARK: - Toolbar
+    
+    @ViewBuilder
+    private var toolbar: some View {
+        HStack {
+            Spacer()
+            Image(systemName: selectedView.imageName)
+                .padding(.trailing, 0)
+            Picker("", selection: $selectedView) {
+                ForEach(views, id: \.self) { method in
+                    Text(String(describing: method.title))
+                }
+            }
+            .frame(maxWidth: 160)
+            .padding(.leading, -10)
+            .onChange(of: selectedView) { value in
+                self.page = 1
+                self.loadContent()
+            }
+            if selectedView == views[0] {
+                Image(systemName: selectedCommentSortType.image)
+                    .padding(.trailing, 0)
+                Picker("", selection: $selectedCommentSortType) {
+                    ForEach(CommentSortType.allCases, id: \.self) { method in
+                        Text(String(describing: method))
+                    }
+                }
+                .frame(maxWidth: 80)
+                .padding(.leading, -10)
+                .onChange(of: selectedCommentSortType) { value in
+                    self.page = 1
+                    self.loadContent()
+                }
+            }
+            Button(action: {
+                self.page = 1
+                self.loadContent()
+            }) {
+                Image(systemName: "arrow.clockwise")
+            }
+            Toggle("Unread Only", isOn: $unreadOnly)
+                .onChange(of: unreadOnly) { value in
+                    self.page = 1
+                    self.loadContent()
+                }
+            Spacer()
+            if selectedView == views[0] {
+                Button(action: markAllAsRead) {
+                    Image(systemName: "envelope.open")
+                }.buttonStyle(.link)
+            }
+        }
+    }
+    
+    // MARK: -
+    
+    @ViewBuilder
+    private func loadingIndicator(visible: Bool) -> some View {
+        if visible {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+    
+    @ViewBuilder
+    private func inboxContents(for selectedView: Option) -> some View {
+        switch selectedView {
+        case views[1]:
+            privateMessagesView
+        default:
+            commentRepliesView
+        }
+    }
+    
+    @ViewBuilder
+    private var privateMessagesView: some View {
+        if privateMessages.count == 0 && !isLoading {
+            Text("You don't have any private messages.")
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+        } else {
+            ForEach(privateMessages, id: \.self) { privateMessage in
+                PrivateMessageUIView(privateMessageView: privateMessage, privateMessageService: privateMessageService!, myself: $myself, contentView: self.contentView, unreadOnlyMode: $unreadOnly)
+                    .onAppear {
+                        if privateMessage == privateMessages.last {
+                            page += 1
+                            loadContent()
+                        }
+                    }
+                Spacer()
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var commentRepliesView: some View {
+        if commentReplies.count == 0 && !isLoading {
+            Text("You don't have any replies.")
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+        } else {
+            ForEach(commentReplies, id: \.self) { commentReply in
+                CommentReplyUIView(commentReplyView: commentReply, commentService: commentService, myself: $myself, contentView: contentView, unreadOnlyMode: $unreadOnly)
+                    .onAppear {
+                        if commentReply == commentReplies.last {
+                            page += 1
+                            loadContent()
+                        }
+                    }
+                Spacer()
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var footerText: some View {
+        if selectedView == views[1] {
+            Spacer()
+            Text("DISCLAIMER: Private messages in Lemmy are not secure.")
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+    
+    // MARK: -
     
     func loadContent() {
         if page == 1 {

--- a/Leomard/Views/NavbarView.swift
+++ b/Leomard/Views/NavbarView.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 
+/// Sidebar root view for this app's `NavigationSplitView`.
 struct NavbarView: View {
     let options: [Option]
     @Binding var profileOption: Option

--- a/Leomard/Views/PreferenceView.swift
+++ b/Leomard/Views/PreferenceView.swift
@@ -35,112 +35,16 @@ struct PreferencesView: View {
     
     var body: some View {
         NavigationSplitView {
-            List {
-                ForEach(preferenceOptions, id: \.self) { option in
-                    HStack {
-                        VStack {
-                            Image(systemName: option.icon)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(
-                                    width: 14,
-                                    height: 14
-                                )
-                                .foregroundColor(.white)
-                                .padding(3)
-                        }
-                        .background(option.color)
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
-                        .frame(
-                            width: 20, height: 20
-                            )
-                        Text(option.name)
-                            .frame(
-                                maxWidth: .infinity,
-                                alignment: .leading
-                            )
-                            .foregroundColor(currentSelection == option ? Color(.linkColor) : Color(.labelColor))
-                        Spacer()
-                    }
-                    .padding(.bottom, 10)
-                    .onTapGesture {
-                        self.currentSelection = option
-                    }
-                }
-            }
-            .listStyle(SidebarListStyle())
-            .navigationBarBackButtonHidden(true)
+            preferencesSidebar
+                .listStyle(SidebarListStyle())
+                .navigationBarBackButtonHidden(true)
         } detail: {
-            List {
-                VStack(alignment: .leading, spacing: 20) {
-                    switch currentSelection {
-                    case self.preferenceOptions[0]:
-                        VStack{
-                            Picker("Check notifications every", selection: $selectedNotificaitonCheckFrequency) {
-                                ForEach(self.notificationCheckFrequencies, id: \.self) { option in
-                                    /*@START_MENU_TOKEN@*/Text(option.name)/*@END_MENU_TOKEN@*/
-                                }
-                            }
-                            .onChange(of: selectedNotificaitonCheckFrequency) { value in
-                                UserPreferences.getInstance.checkNotifsEverySeconds = value.seconds
-                            }
-                            Text("Note: Notifications are not checked when app is closed.")
-                                .frame(maxWidth: .infinity, alignment:.leading)
-                                .lineLimit(nil)
-                        }
-                        VStack(alignment: .leading) {
-                            Text("Inbox")
-                            Toggle("Show Unread only by default", isOn: UserPreferences.getInstance.$unreadonlyWhenOpeningInbox)
-                        }
-                    case self.preferenceOptions[1]:
-                        VStack(alignment: .leading) {
-                            Picker("Default post sort method", selection: UserPreferences.getInstance.$postSortMethod) {
-                                ForEach(UserPreferences.getInstance.sortTypes, id: \.self) { method in
-                                    Text(String(describing: method))
-                                }
-                            }
-                            Picker("Default comment sort method", selection: UserPreferences.getInstance.$commentSortMethod) {
-                                ForEach(CommentSortType.allCases, id: \.self) { method in
-                                    Text(String(describing: method))
-                                }
-                            }
-                            Picker("Default listing type", selection: UserPreferences.getInstance.$listType) {
-                                ForEach(ListingType.allCases, id: \.self) { method in
-                                    Text(String(describing: method))
-                                }
-                            }
-                            Picker("Default profile sort method", selection: UserPreferences.getInstance.$profileSortMethod) {
-                                ForEach(UserPreferences.getInstance.profileSortTypes, id: \.self) { method in
-                                    Text(String(describing: method))
-                                }
-                            }
-                        }
-                        VStack(alignment: .leading) {
-                            Text("NSFW")
-                            Toggle("Show NSFW content", isOn: UserPreferences.getInstance.$showNsfw)
-                            Toggle("Blur NSFW content", isOn: UserPreferences.getInstance.$blurNsfw)
-                        }
-                    case preferenceOptions[2]:
-                        VStack(alignment: .leading) {
-                            Toggle("Cross Instance Search", isOn: UserPreferences.getInstance.$experimentXInstanceSearch)
-                            Text("""
-                         Use '@instance.name' at the end of the search query, to search using other Lemmy instance from your own.
-                         Example: 'awesome post @lemmy.world'
-                         """)
-                            .frame(maxWidth: .infinity)
-                            .lineLimit(nil)
-                        }
-                    default:
-                        Text("")
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .padding(.leading)
-            .padding(.trailing)
-            .listStyle(SidebarListStyle())
-            .scrollContentBackground(.hidden)
-            .frame(maxWidth: .infinity)
+            preferencePanel(for: currentSelection)
+                .padding(.leading)
+                .padding(.trailing)
+                .listStyle(SidebarListStyle())
+                .scrollContentBackground(.hidden)
+                .frame(maxWidth: .infinity)
         }
         .task {
             self.currentSelection = self.preferenceOptions[0]
@@ -154,6 +58,136 @@ struct PreferencesView: View {
             if selectedNotificaitonCheckFrequency.name == "Err" {
                 selectedNotificaitonCheckFrequency = notificationCheckFrequencies[3]
             }
+        }
+    }
+    
+    // MARK: - Sidebar
+    
+    @ViewBuilder
+    private var preferencesSidebar: some View {
+        List {
+            ForEach(preferenceOptions, id: \.self) { option in
+                preferenceSidebarItem(option: option)
+                    .padding(.bottom, 10)
+                    .onTapGesture {
+                        self.currentSelection = option
+                    }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private func preferenceSidebarItem(option: PreferenceOption) -> some View {
+        HStack {
+            VStack {
+                Image(systemName: option.icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(
+                        width: 14,
+                        height: 14
+                    )
+                    .foregroundColor(.white)
+                    .padding(3)
+            }
+            .background(option.color)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .frame(
+                width: 20, height: 20
+            )
+            Text(option.name)
+                .frame(
+                    maxWidth: .infinity,
+                    alignment: .leading
+                )
+                .foregroundColor(currentSelection == option ? Color(.linkColor) : Color(.labelColor))
+            Spacer()
+        }
+    }
+    
+    // MARK: - Detail
+    
+    @ViewBuilder
+    private func preferencePanel(for currentSelection: PreferenceOption?) -> some View {
+        List {
+            VStack(alignment: .leading, spacing: 20) {
+                switch currentSelection {
+                case self.preferenceOptions[0]:
+                    generalPreferences
+                case self.preferenceOptions[1]:
+                    contentPreferences
+                case preferenceOptions[2]:
+                    experimentalPreferences
+                default:
+                    Text("")
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+    
+    @ViewBuilder
+    private var generalPreferences: some View {
+        VStack{
+            Picker("Check notifications every", selection: $selectedNotificaitonCheckFrequency) {
+                ForEach(self.notificationCheckFrequencies, id: \.self) { option in
+                    Text(option.name)
+                }
+            }
+            .onChange(of: selectedNotificaitonCheckFrequency) { value in
+                UserPreferences.getInstance.checkNotifsEverySeconds = value.seconds
+            }
+            Text("Note: Notifications are not checked when app is closed.")
+                .frame(maxWidth: .infinity, alignment:.leading)
+                .lineLimit(nil)
+        }
+        VStack(alignment: .leading) {
+            Text("Inbox")
+            Toggle("Show Unread only by default", isOn: UserPreferences.getInstance.$unreadonlyWhenOpeningInbox)
+        }
+    }
+    
+    @ViewBuilder
+    private var contentPreferences: some View {
+        VStack(alignment: .leading) {
+            Picker("Default post sort method", selection: UserPreferences.getInstance.$postSortMethod) {
+                ForEach(UserPreferences.getInstance.sortTypes, id: \.self) { method in
+                    Text(String(describing: method))
+                }
+            }
+            Picker("Default comment sort method", selection: UserPreferences.getInstance.$commentSortMethod) {
+                ForEach(CommentSortType.allCases, id: \.self) { method in
+                    Text(String(describing: method))
+                }
+            }
+            Picker("Default listing type", selection: UserPreferences.getInstance.$listType) {
+                ForEach(ListingType.allCases, id: \.self) { method in
+                    Text(String(describing: method))
+                }
+            }
+            Picker("Default profile sort method", selection: UserPreferences.getInstance.$profileSortMethod) {
+                ForEach(UserPreferences.getInstance.profileSortTypes, id: \.self) { method in
+                    Text(String(describing: method))
+                }
+            }
+        }
+        VStack(alignment: .leading) {
+            Text("NSFW")
+            Toggle("Show NSFW content", isOn: UserPreferences.getInstance.$showNsfw)
+            Toggle("Blur NSFW content", isOn: UserPreferences.getInstance.$blurNsfw)
+        }
+    }
+    
+    @ViewBuilder
+    private var experimentalPreferences: some View {
+        VStack(alignment: .leading) {
+            Toggle("Cross Instance Search", isOn: UserPreferences.getInstance.$experimentXInstanceSearch)
+            Text("""
+                         Use '@instance.name' at the end of the search query, to search using other Lemmy instance from your own.
+                         Example: 'awesome post @lemmy.world'
+                         """)
+            .frame(maxWidth: .infinity)
+            .lineLimit(nil)
         }
     }
 }

--- a/Leomard/Views/ProfileView.swift
+++ b/Leomard/Views/ProfileView.swift
@@ -34,68 +34,13 @@ struct ProfileView: View {
     @State var sessionChangeFail: Bool = false
     
     var body: some View {
-        HStack {
-            if person != myself?.localUserView.person {
-                Button("Dismiss", action: contentView.dismissProfileView)
-                    .buttonStyle(.link)
-            }
-            Spacer()
-            HStack {
-                HStack {
-                    Image(systemName: selectedBrowseOption.imageName)
-                        .padding(.trailing, 0)
-                    Picker("", selection: $selectedBrowseOption) {
-                        ForEach(browseOptions, id: \.self) { method in
-                            Text(method.title)
-                        }
-                    }
-                    .frame(maxWidth: 120)
-                    .padding(.leading, -10)
-                    .onChange(of: selectedBrowseOption) { value in
-                        self.reloadFeed()
-                    }
-                    Image(systemName: selectedSort.image)
-                        .padding(.trailing, 0)
-                    Picker("", selection: $selectedSort) {
-                        ForEach(UserPreferences.getInstance.profileSortTypes, id: \.self) { method in
-                            Text(String(describing: method))
-                        }
-                    }
-                    .frame(maxWidth: 80)
-                    .padding(.leading, -10)
-                    .onChange(of: selectedSort) { value in
-                        self.reloadFeed()
-                    }
-                }
-                Button(action: reloadFeed) {
-                    Image(systemName: "arrow.clockwise")
-                }
-            }
-            Spacer()
-            HStack {
-                if person == myself?.localUserView.person {
-                    Picker("", selection: $selectededSession) {
-                        ForEach(sessions, id: \.self) { session in
-                            if sessions.last == session {
-                                Divider()
-                            }
-                            Text(session.title)
-                        }
-                    }
-                    .frame(maxWidth: 120)
-                    .onChange(of: selectededSession) { change in
-                        performSwitch(change)
-                    }
-                    Button("Logout", action: logout)
-                }
-            }
-        }
-        .frame(
-            minWidth: 0,
-            maxWidth: .infinity
-        )
-        .padding(.leading)
-        .padding(.trailing)
+        toolbar
+            .frame(
+                minWidth: 0,
+                maxWidth: .infinity
+            )
+            .padding(.leading)
+            .padding(.trailing)
         VStack {
             GeometryReader { proxy in
                 HStack {
@@ -218,6 +163,84 @@ struct ProfileView: View {
         }
         Spacer()
     }
+    
+    @ViewBuilder
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            dismissButton
+            Spacer()
+            profileToolbarItems
+            Spacer()
+            sessionPicker
+        }
+    }
+    
+    @ViewBuilder
+    private var dismissButton: some View {
+        if person != myself?.localUserView.person {
+            Button("Dismiss", action: contentView.dismissProfileView)
+                .buttonStyle(.link)
+        }
+    }
+    
+    @ViewBuilder
+    private var profileToolbarItems: some View {
+        HStack {
+            HStack {
+                Image(systemName: selectedBrowseOption.imageName)
+                    .padding(.trailing, 0)
+                Picker("", selection: $selectedBrowseOption) {
+                    ForEach(browseOptions, id: \.self) { method in
+                        Text(method.title)
+                    }
+                }
+                .frame(maxWidth: 120)
+                .padding(.leading, -10)
+                .onChange(of: selectedBrowseOption) { value in
+                    self.reloadFeed()
+                }
+                Image(systemName: selectedSort.image)
+                    .padding(.trailing, 0)
+                Picker("", selection: $selectedSort) {
+                    ForEach(UserPreferences.getInstance.profileSortTypes, id: \.self) { method in
+                        Text(String(describing: method))
+                    }
+                }
+                .frame(maxWidth: 80)
+                .padding(.leading, -10)
+                .onChange(of: selectedSort) { value in
+                    self.reloadFeed()
+                }
+            }
+            Button(action: reloadFeed) {
+                Image(systemName: "arrow.clockwise")
+            }
+        }
+    }
+    
+    /// Select a user/instance, or logout.
+    @ViewBuilder
+    private var sessionPicker: some View {
+        HStack {
+            if person == myself?.localUserView.person {
+                Picker("", selection: $selectededSession) {
+                    ForEach(sessions, id: \.self) { session in
+                        if sessions.last == session {
+                            Divider()
+                        }
+                        Text(session.title)
+                    }
+                }
+                .frame(maxWidth: 120)
+                .onChange(of: selectededSession) { change in
+                    performSwitch(change)
+                }
+                Button("Logout", action: logout)
+            }
+        }
+    }
+    
+    // MARK: -
     
     func logout() {
         _ = SessionStorage.getInstance.endSession()

--- a/Leomard/Views/SearchView.swift
+++ b/Leomard/Views/SearchView.swift
@@ -29,6 +29,49 @@ struct SearchView: View {
     @FocusState var searchFocused: Bool
 
     var body: some View {
+        searchBar
+            .frame(
+                minWidth: 0,
+                idealWidth: .infinity
+            )
+            .padding(.leading)
+            .padding(.trailing)
+            .task {
+                searchFocused = true
+            }
+        VStack {
+            HStack {
+                ScrollViewReader { _ in
+                    searchProgressView(visible: self.searching && page == 1)
+                    searchResultsList(selectedSearchType: selectedSearchType)
+                        .frame(
+                            minWidth: 0,
+                            maxWidth: 600,
+                            maxHeight: .infinity,
+                            alignment: .center
+                        )
+                }
+                .frame(
+                    maxWidth: .infinity,
+                    alignment: .center
+                )
+            }
+            .cornerRadius(4)
+            Spacer()
+        }
+        .task {
+            self.searchQuery = ""
+            self.selectedSearchType = .communities
+
+            let requestHandler = RequestHandler()
+            self.searchService = SearchService(requestHandler: requestHandler)
+        }
+    }
+    
+    // MARK: - Search Form
+    
+    @ViewBuilder
+    private var searchBar: some View {
         HStack {
             Spacer()
             VStack {
@@ -60,181 +103,164 @@ struct SearchView: View {
             }
             Spacer()
         }
-        .frame(
-            minWidth: 0,
-            idealWidth: .infinity
-        )
-        .padding(.leading)
-        .padding(.trailing)
-        .task {
-            searchFocused = true
-        }
-        VStack {
-            HStack {
-                ScrollViewReader { _ in
-                    if self.searching && page == 1 {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                    }
-
-                    switch selectedSearchType {
-                    case .comments:
-                        if searchResponse.comments == [] && !self.searching && self.searchedOnce {
-                            Text("No comments found!")
-                                .italic()
-                                .foregroundColor(.secondary)
-                        }
-                        List {
-                            ForEach(searchResponse.comments, id: \.self) { commentView in
-                                VStack {
-                                    CommentUIView(commentView: commentView, indentLevel: 1, commentService: commentService, myself: $myself, post: commentView.post, contentView: contentView)
-                                        .onAppear {
-                                            if commentView == searchResponse.comments.last {
-                                                self.search()
-                                            }
-                                        }
-                                        .frame(
-                                            maxWidth: .infinity,
-                                            maxHeight: .infinity
-                                        )
-                                        .padding(.top, 15)
-                                        .padding(.bottom, 15)
-                                        .padding(.trailing, 15)
-                                }
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .background(Color(.textBackgroundColor))
-                                .cornerRadius(4)
-                                .onTapGesture {
-                                    self.loadPostFromComment(commentView: commentView)
-                                }
-                                Spacer()
-                                    .frame(height: 0)
-
-                            }
-                        }
-                        .frame(
-                            minWidth: 0,
-                            maxWidth: 600,
-                            maxHeight: .infinity,
-                            alignment: .center
-                        )
-                    case .communities:
-                        if searchResponse.communities == [] && !self.searching && self.searchedOnce {
-                            Text("No communities found!")
-                                .italic()
-                                .foregroundColor(.secondary)
-                        }
-                        List {
-                            ForEach(searchResponse.communities, id: \.self) { communityView in
-                                VStack {
-                                    CommunitySearchUIView(communityView: communityView, contentView: contentView)
-                                        .onAppear {
-                                            if communityView == searchResponse.communities.last {
-                                                self.search()
-                                            }
-                                        }
-                                        .frame(
-                                            maxWidth: .infinity,
-                                            maxHeight: .infinity
-                                        )
-                                        .padding(.top, 15)
-                                        .padding(.bottom, 15)
-                                        .padding(.trailing, 15)
-                                }
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .background(Color(.textBackgroundColor))
-                                .cornerRadius(4)
-                                Spacer()
-                                    .frame(height: 0)
-
-                            }
-                        }
-                        .frame(
-                            minWidth: 0,
-                            maxWidth: 600,
-                            maxHeight: .infinity,
-                            alignment: .center
-                        )
-                    case .users:
-                        if searchResponse.users == [] && !self.searching && self.searchedOnce {
-                            Text("No users found!")
-                                .italic()
-                                .foregroundColor(.secondary)
-                        }
-                        List {
-                            ForEach(searchResponse.users, id: \.self) { personView in
-                                VStack {
-                                    UserSearchUIView(personView: personView, contentView: contentView)
-                                        .onAppear {
-                                            if personView == searchResponse.users.last {
-                                                self.search()
-                                            }
-                                        }
-                                        .frame(
-                                            maxWidth: .infinity,
-                                            maxHeight: .infinity
-                                        )
-                                        .padding(.top, 15)
-                                        .padding(.bottom, 15)
-                                        .padding(.trailing, 15)
-                                }
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .background(Color(.textBackgroundColor))
-                                .cornerRadius(4)
-                                Spacer()
-                                    .frame(height: 0)
-
-                            }
-                        }
-                        .frame(
-                            minWidth: 0,
-                            maxWidth: 600,
-                            maxHeight: .infinity,
-                            alignment: .center
-                        )
-                    default:
-                        if searchResponse.posts == [] && !self.searching && self.searchedOnce {
-                            Text("No posts found!")
-                                .italic()
-                                .foregroundColor(.secondary)
-                        }
-                        List {
-                            ForEach(searchResponse.posts, id: \.self) { postView in
-                                PostUIView(postView: postView, shortBody: true, postService: self.postService, myself: $myself, contentView: contentView)
-                                    .onAppear {
-                                        if postView == searchResponse.posts.last {
-                                            self.search()
-                                        }
-                                    }
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                Spacer()
-                                    .frame(height: 0)
-                            }
-                        }
-                        .frame(
-                            minWidth: 0,
-                            maxWidth: 600,
-                            maxHeight: .infinity,
-                            alignment: .center
-                        )
-                    }
-                }
-                .frame(
-                    maxWidth: .infinity,
-                    alignment: .center
-                )
-            }
-            .cornerRadius(4)
-            Spacer()
-        }
-        .task {
-            self.searchQuery = ""
-            self.selectedSearchType = .communities
-
-            let requestHandler = RequestHandler()
-            self.searchService = SearchService(requestHandler: requestHandler)
+    }
+    
+    // MARK: - Search Results
+    
+    @ViewBuilder
+    private func searchProgressView(visible: Bool) -> some View {
+        if visible {
+            ProgressView()
+                .progressViewStyle(.circular)
         }
     }
+    
+    @ViewBuilder
+    private func searchResultsList(selectedSearchType: SearchType) -> some View {
+        switch selectedSearchType {
+        case .comments:
+            commentsList
+        case .communities:
+            communitiesList
+        case .users:
+            usersList
+        default:
+            postsList
+        }
+    }
+    
+    @ViewBuilder
+    private var commentsList: some View {
+        if searchResponse.comments == [] && !self.searching && self.searchedOnce {
+            Text("No comments found!")
+                .italic()
+                .foregroundColor(.secondary)
+        } else {
+            List {
+                ForEach(searchResponse.comments, id: \.self) { commentView in
+                    VStack {
+                        CommentUIView(commentView: commentView, indentLevel: 1, commentService: commentService, myself: $myself, post: commentView.post, contentView: contentView)
+                            .onAppear {
+                                if commentView == searchResponse.comments.last {
+                                    self.search()
+                                }
+                            }
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: .infinity
+                            )
+                            .padding(.top, 15)
+                            .padding(.bottom, 15)
+                            .padding(.trailing, 15)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.textBackgroundColor))
+                    .cornerRadius(4)
+                    .onTapGesture {
+                        self.loadPostFromComment(commentView: commentView)
+                    }
+                    Spacer()
+                        .frame(height: 0)
+                    
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var communitiesList: some View {
+        if searchResponse.communities == [] && !self.searching && self.searchedOnce {
+            Text("No communities found!")
+                .italic()
+                .foregroundColor(.secondary)
+        } else {
+            List {
+                ForEach(searchResponse.communities, id: \.self) { communityView in
+                    VStack {
+                        CommunitySearchUIView(communityView: communityView, contentView: contentView)
+                            .onAppear {
+                                if communityView == searchResponse.communities.last {
+                                    self.search()
+                                }
+                            }
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: .infinity
+                            )
+                            .padding(.top, 15)
+                            .padding(.bottom, 15)
+                            .padding(.trailing, 15)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.textBackgroundColor))
+                    .cornerRadius(4)
+                    Spacer()
+                        .frame(height: 0)
+                    
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var usersList: some View {
+        if searchResponse.users == [] && !self.searching && self.searchedOnce {
+            Text("No users found!")
+                .italic()
+                .foregroundColor(.secondary)
+        } else {
+            List {
+                ForEach(searchResponse.users, id: \.self) { personView in
+                    VStack {
+                        UserSearchUIView(personView: personView, contentView: contentView)
+                            .onAppear {
+                                if personView == searchResponse.users.last {
+                                    self.search()
+                                }
+                            }
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: .infinity
+                            )
+                            .padding(.top, 15)
+                            .padding(.bottom, 15)
+                            .padding(.trailing, 15)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.textBackgroundColor))
+                    .cornerRadius(4)
+                    Spacer()
+                        .frame(height: 0)
+                    
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var postsList: some View {
+        if searchResponse.posts == [] && !self.searching && self.searchedOnce {
+            Text("No posts found!")
+                .italic()
+                .foregroundColor(.secondary)
+        } else {
+            List {
+                ForEach(searchResponse.posts, id: \.self) { postView in
+                    PostUIView(postView: postView, shortBody: true, postService: self.postService, myself: $myself, contentView: contentView)
+                        .onAppear {
+                            if postView == searchResponse.posts.last {
+                                self.search()
+                            }
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    Spacer()
+                        .frame(height: 0)
+                }
+            }
+        }
+    }
+    
+    // MARK: -
 
     func search() {
         if self.searchQuery == "" {


### PR DESCRIPTION
See list of refactored top-level views here: #20 
- It's now easier to pick out from `var body` implementations what a view is composed of, as opposed to how it's constructed.
- Implementation details are now contained in private view builders.

Some Possible Next Steps for another day:
- Some clear patterns emerged while refactoring, including:
> Toolbar logic is replicated across views, which could later be extracted.
> Use of `GeometryReader` and nested `ScrollViewReader`, where the former could be replaced with a `.preference(key)` view modifier, and the latter removed (it doesn't appear the ScrollViewReaders are actually being used). These readers are expensive, and could be causing some scrolling performance issues (I haven't actually benchmarked this, just guesstimating 😅).

Other Notes:
- Didn't change any implementation, apart from removing some forced/optional unwraps that were no longer necessary.
- Didn't refactor any of the views in the `/Components` and `/Popups` directories.