### PR TITLE
Hot fix missing early exit

### DIFF
--- a/Leomard/Views/CommunityUIView.swift
+++ b/Leomard/Views/CommunityUIView.swift
@@ -303,6 +303,10 @@ struct CommunityUIView: View {
             return
         }
         
+        guard isLoading == false else {
+            return
+        }
+        
         isLoading = true
         
         self.postService.getPostsForCommunity(community: self.communityResponse!.communityView.community, page: page) { result in
@@ -318,7 +322,12 @@ struct CommunityUIView: View {
     }
     
     func loadComments() {
+        guard isLoading == false else {
+            return
+        }
+        
         isLoading = true
+        
         self.commentService.getCommentsForCommunity(community: self.communityResponse!.communityView.community, page: page) { result in
             isLoading = false
             switch result {


### PR DESCRIPTION
- Add missing early exit statements in `CommunityUIView` data loading functions.
- Use separate states to track loading state when fething Community/Post/Comments/searching.